### PR TITLE
Shiny/Mega icon alignment + Full Odds Tracker

### DIFF
--- a/Data/Scripts/011_Battle/003_Scene/006_Battle_Scene_Objects.rb
+++ b/Data/Scripts/011_Battle/003_Scene/006_Battle_Scene_Objects.rb
@@ -272,8 +272,9 @@ class Battle::Scene::PokemonDataBox < Sprite
   def draw_shiny_icon
     return if !@battler.shiny?
     #shiny_x = (@battler.opposes?(0)) ? 206 : -6   # Foe's/player's
-    shiny_x = (@battler.opposes?(0)) ? 220 : 24   # Foe's/player's
-    pbDrawImagePositions(self.bitmap, [["Graphics/Pictures/shiny", @spriteBaseX + shiny_x, 36]])
+    shiny_x = (@battler.opposes?(0)) ? 220 : 8   # Foe's/player's
+    shiny_y = (@battler.opposes?(0)) ? 36 : 48  # Foe's/player's
+    pbDrawImagePositions(self.bitmap, [["Graphics/Pictures/shiny", @spriteBaseX + shiny_x, shiny_y]])
   end
 
   def draw_special_form_icon

--- a/Data/Scripts/011_Battle/003_Scene/006_Battle_Scene_Objects.rb
+++ b/Data/Scripts/011_Battle/003_Scene/006_Battle_Scene_Objects.rb
@@ -280,7 +280,9 @@ class Battle::Scene::PokemonDataBox < Sprite
   def draw_special_form_icon
     # Mega Evolution/Primal Reversion icon
     if @battler.mega?
-      pbDrawImagePositions(self.bitmap, [["Graphics/Pictures/Battle/icon_mega", @spriteBaseX + 8, 34]])
+      mega_x = (@battler.opposes?(0)) ? 222 : 6   # Foe's/player's
+      mega_y = (@battler.opposes?(0)) ? 36 : 49  # Foe's/player's
+      pbDrawImagePositions(self.bitmap, [["Graphics/Pictures/Battle/icon_mega", @spriteBaseX + mega_x, mega_y]])
     elsif @battler.primal?
       filename = nil
       if @battler.isSpecies?(:GROUDON)

--- a/Data/Scripts/044_Untamed Custom Misc/007_Clover Catch Chain.rb
+++ b/Data/Scripts/044_Untamed Custom Misc/007_Clover Catch Chain.rb
@@ -30,10 +30,7 @@ def chainBonuses(mon,species)
       shinyrate = Settings::SHINY_POKEMON_CHANCE
     end
     v = (65_536 / shinyrate.to_f).ceil
-    if rand(65_536) < v
-      mon.shiny = true
-      # Sets shiny roll count to 2 so this isn't registered as a full-odds shiny
-      mon.shiny_roll_count = 2
+    mon.shiny = true if rand(65_536) < v
   end
 end
 

--- a/Data/Scripts/044_Untamed Custom Misc/007_Clover Catch Chain.rb
+++ b/Data/Scripts/044_Untamed Custom Misc/007_Clover Catch Chain.rb
@@ -30,7 +30,10 @@ def chainBonuses(mon,species)
       shinyrate = Settings::SHINY_POKEMON_CHANCE
     end
     v = (65_536 / shinyrate.to_f).ceil
-    mon.shiny = true if rand(65_536) < v
+    if rand(65_536) < v
+      mon.shiny = true
+      # Sets shiny roll count to 2 so this isn't registered as a full-odds shiny
+      mon.shiny_roll_count = 2
   end
 end
 

--- a/Plugins/Full Odds Tracker/Script.rb
+++ b/Plugins/Full Odds Tracker/Script.rb
@@ -1,0 +1,108 @@
+class Pokemon
+  # @return [Integer] the number of times this pokemon has rolled for shininess
+  attr_reader   :shiny_roll_count
+
+  # Indicates full odds, not shininess - a non-shiny pokemon can still return true
+  # on this, as long as no shiny odds changes were active when caught
+  # @return [Boolean] whether this pokemon's shininess was determined at full odds
+  def full_odds?
+    return @shiny_roll_count == 1
+  end
+
+  # Shiny calculation - overriden from Scripts/014_Pokemon/001_Pokemon.rb to keep track of shiny rolls
+  # @return [Boolean] whether this Pokémon is shiny (differently colored)
+  def shiny?
+    if @shiny.nil?
+      @shiny_roll_count += 1
+      a = @personalID ^ @owner.id
+      b = a & 0xFFFF
+      c = (a >> 16) & 0xFFFF
+      d = b ^ c
+      @shiny = d < Settings::SHINY_POKEMON_CHANCE
+    end
+    return @shiny
+  end
+
+  # Creates a new Pokémon object - overriden from Scripts/014_Pokemon/001_Pokemon.rb to initialise counter for shiny rolls
+  # @param species [Symbol, String, GameData::Species] Pokémon species
+  # @param level [Integer] Pokémon level
+  # @param owner [Owner, Player, NPCTrainer] Pokémon owner (the player by default)
+  # @param withMoves [Boolean] whether the Pokémon should have moves
+  # @param recheck_form [Boolean] whether to auto-check the form
+  def initialize(species, level, owner = $player, withMoves = true, recheck_form = true)
+    species_data = GameData::Species.get(species)
+    @species          = species_data.species
+    @form             = species_data.base_form
+    @forced_form      = nil
+    @time_form_set    = nil
+    self.level        = level
+    @steps_to_hatch   = 0
+    heal_status
+    @gender           = nil
+    @shiny            = nil
+    @shiny_roll_count = 0
+    @ability_index    = nil
+    @ability          = nil
+    @nature           = nil
+    @nature_for_stats = nil
+    @item             = nil
+    @mail             = nil
+    @moves            = []
+    reset_moves if withMoves
+    @first_moves      = []
+    @ribbons          = []
+    @cool             = 0
+    @beauty           = 0
+    @cute             = 0
+    @smart            = 0
+    @tough            = 0
+    @sheen            = 0
+    @pokerus          = 0
+    @name             = nil
+    @happiness        = species_data.happiness
+    @poke_ball        = :POKEBALL
+    @markings         = []
+    @iv               = {}
+    @ivMaxed          = {}
+    @ev               = {}
+    GameData::Stat.each_main do |s|
+      @iv[s.id]       = 0#rand(IV_STAT_LIMIT + 1) #by low
+      @ev[s.id]       = 0
+    end
+    case owner
+    when Owner
+      @owner = owner
+    when Player, NPCTrainer
+      @owner = Owner.new_from_trainer(owner)
+    else
+      @owner = Owner.new(0, "", 2, 2)
+    end
+    @obtain_method    = 0   # Met
+    @obtain_method    = 4 if $game_switches && $game_switches[Settings::FATEFUL_ENCOUNTER_SWITCH]
+    @obtain_map       = ($game_map) ? $game_map.map_id : 0
+    @obtain_text      = nil
+    @obtain_level     = level
+    @hatched_map      = 0
+    @timeReceived     = pbGetTimeNow.to_i
+    @timeEggHatched   = nil
+    @fused            = nil
+    @personalID       = rand(2**16) | (rand(2**16) << 16)
+    @hp               = 1
+    @totalhp          = 1
+    #by low
+    @evolution_steps  = 0
+    @remaningHPBars   = [0, 0] # current, max hp bar
+    @hpbarsstorage    = [0, 0] # break, restore hp bar
+    @willmega         = false
+    @sketchMove       = nil
+    calc_stats
+    if @form == 0 && recheck_form
+      f = MultipleForms.call("getFormOnCreation", self)
+      if f
+        self.form = f
+        reset_moves if withMoves
+      end
+    end
+  end
+end
+        

--- a/Plugins/Full Odds Tracker/Script.rb
+++ b/Plugins/Full Odds Tracker/Script.rb
@@ -1,3 +1,14 @@
+#==============================================================================
+# Full Odds Tracker
+# This adds the method 'full_odds' to pokemon, that returns false if any shiny
+# odds affecting mechanics are in play. It does it's best to catch this at
+# all passes - if the shininess is re-rolled, if the shininess is set to true,
+# or if specific mechanics are in play like the shiny charm.
+#
+# This should catch mostly everything, but you can edit the event handlers to
+# add some custom stuff if you want.
+#==============================================================================
+
 class Pokemon
   # Number of times this pokemon has rolled for shininess
   # Can be set to 2 to manually mark as not-full-odds
@@ -15,7 +26,7 @@ class Pokemon
     if @shiny.nil?
       @shiny_roll_count = 0 if @shiny_roll_count.nil?
       @shiny_roll_count = @shiny_roll_count + 1
-      echoln "Rolling for shininess..."
+      # echoln "Rolling for shininess..."
     end
     return fo_shiny?
   end
@@ -25,21 +36,38 @@ class Pokemon
   def shiny=(value)
     @shiny_roll_count = 2 if value == true
     if value == true
-        echoln "Invalidated due to set shiny"
+        # echoln "Invalidated due to set shiny"
     end
     @shiny = value
   end
 end
 
+# Accounting for Masuda method for increasing shiny chance
+class DayCare
+  module EggGenerator
+    alias set_shininess fo_set_shininess
+    def set_shininess(egg, mother, father)
+      if father.owner.language != mother.owner.language
+        egg.shiny_roll_count = 2;
+      end
+      fo_set_shininess(egg, mother, father)
+    end
+  end
+end
+      
+
+# Manually marks as not-full-odds for scenarios where shiny odds are effected - 
+# redundant except in very rare situations (rolled a shiny on the first try 
+# despite having multiple tries due to some shiny_chance affecting mechanic)
 EventHandlers.add(:on_wild_pokemon_created, :full_odds_switch,
   proc { |pkmn|
     if $bag.has?(:SHINYCHARM)
         pkmn.shiny_roll_count = 2
-        echoln "Invalidated due to shiny charm"
+        # echoln "Invalidated due to shiny charm"
     end
     if $player.pokedex.battled_count(pkmn.species) > 51 && Settings::HIGHER_SHINY_CHANCES_WITH_NUMBER_BATTLED
         pkmn.shiny_roll_count = 2
-        echoln "Invalidated due to higher shiny chance from number fought"
+        # echoln "Invalidated due to higher shiny chance from number fought"
     end
   }
 )

--- a/Plugins/Full Odds Tracker/Script.rb
+++ b/Plugins/Full Odds Tracker/Script.rb
@@ -1,6 +1,6 @@
 class Pokemon
   # Number of times this pokemon has rolled for shininess
-  attr_reader   :shiny_roll_count
+  attr_accessor   :shiny_roll_count
 
   # Indicates full odds, not shininess - a non-shiny pokemon can still return true
   # on this, as long as no shiny odds changes were active when caught

--- a/Plugins/Full Odds Tracker/Script.rb
+++ b/Plugins/Full Odds Tracker/Script.rb
@@ -3,7 +3,7 @@
 # This adds the method 'full_odds' to pokemon, that returns false if any shiny
 # odds affecting mechanics are in play. It does it's best to catch this at
 # all passes - if the shininess is re-rolled, if the shininess is set to true,
-# or if specific mechanics are in play like the shiny charm.
+# or if specific mechanics are in play like the shiny charm or masuda method.
 #
 # This should catch mostly everything, but you can edit the event handlers to
 # add some custom stuff if you want.
@@ -36,7 +36,7 @@ class Pokemon
   def shiny=(value)
     @shiny_roll_count = 2 if value == true
     if value == true
-        # echoln "Invalidated due to set shiny"
+        # echoln "Invalidated as full odds due to set shiny"
     end
     @shiny = value
   end
@@ -45,10 +45,11 @@ end
 # Accounting for Masuda method for increasing shiny chance
 class DayCare
   module EggGenerator
-    alias set_shininess fo_set_shininess
+    alias fo_set_shininess set_shininess
     def set_shininess(egg, mother, father)
       if father.owner.language != mother.owner.language
         egg.shiny_roll_count = 2;
+        # echoln "Invalidated as full odds due to Masuda method"
       end
       fo_set_shininess(egg, mother, father)
     end
@@ -56,18 +57,18 @@ class DayCare
 end
       
 
-# Manually marks as not-full-odds for scenarios where shiny odds are effected - 
+# Manually marks as not-full-odds for scenarios where shiny odds are affected - 
 # redundant except in very rare situations (rolled a shiny on the first try 
 # despite having multiple tries due to some shiny_chance affecting mechanic)
 EventHandlers.add(:on_wild_pokemon_created, :full_odds_switch,
   proc { |pkmn|
     if $bag.has?(:SHINYCHARM)
         pkmn.shiny_roll_count = 2
-        # echoln "Invalidated due to shiny charm"
+        # echoln "Invalidated as full odds due to shiny charm"
     end
     if $player.pokedex.battled_count(pkmn.species) > 51 && Settings::HIGHER_SHINY_CHANCES_WITH_NUMBER_BATTLED
         pkmn.shiny_roll_count = 2
-        # echoln "Invalidated due to higher shiny chance from number fought"
+        # echoln "Invalidated as full odds due to higher shiny chance from number fought"
     end
   }
 )

--- a/Plugins/Full Odds Tracker/Script.rb
+++ b/Plugins/Full Odds Tracker/Script.rb
@@ -1,108 +1,27 @@
 class Pokemon
-  # @return [Integer] the number of times this pokemon has rolled for shininess
+  # Number of times this pokemon has rolled for shininess
   attr_reader   :shiny_roll_count
 
   # Indicates full odds, not shininess - a non-shiny pokemon can still return true
   # on this, as long as no shiny odds changes were active when caught
-  # @return [Boolean] whether this pokemon's shininess was determined at full odds
   def full_odds?
     return @shiny_roll_count == 1
   end
 
-  # Shiny calculation - overriden from Scripts/014_Pokemon/001_Pokemon.rb to keep track of shiny rolls
-  # @return [Boolean] whether this Pokémon is shiny (differently colored)
+  alias fo_shiny? shiny?
+  # Shiny calculation - added code to keep track of shiny rolls
   def shiny?
     if @shiny.nil?
       @shiny_roll_count += 1
-      a = @personalID ^ @owner.id
-      b = a & 0xFFFF
-      c = (a >> 16) & 0xFFFF
-      d = b ^ c
-      @shiny = d < Settings::SHINY_POKEMON_CHANCE
     end
-    return @shiny
+    return fo_shiny?
   end
 
-  # Creates a new Pokémon object - overriden from Scripts/014_Pokemon/001_Pokemon.rb to initialise counter for shiny rolls
-  # @param species [Symbol, String, GameData::Species] Pokémon species
-  # @param level [Integer] Pokémon level
-  # @param owner [Owner, Player, NPCTrainer] Pokémon owner (the player by default)
-  # @param withMoves [Boolean] whether the Pokémon should have moves
-  # @param recheck_form [Boolean] whether to auto-check the form
-  def initialize(species, level, owner = $player, withMoves = true, recheck_form = true)
-    species_data = GameData::Species.get(species)
-    @species          = species_data.species
-    @form             = species_data.base_form
-    @forced_form      = nil
-    @time_form_set    = nil
-    self.level        = level
-    @steps_to_hatch   = 0
-    heal_status
-    @gender           = nil
-    @shiny            = nil
+  alias fo_initialize initialize
+  # Creates a new Pokémon object - added code to initialise counter for shiny rolls
+  def initialize(*args)
+    fo_initialize(*args)
     @shiny_roll_count = 0
-    @ability_index    = nil
-    @ability          = nil
-    @nature           = nil
-    @nature_for_stats = nil
-    @item             = nil
-    @mail             = nil
-    @moves            = []
-    reset_moves if withMoves
-    @first_moves      = []
-    @ribbons          = []
-    @cool             = 0
-    @beauty           = 0
-    @cute             = 0
-    @smart            = 0
-    @tough            = 0
-    @sheen            = 0
-    @pokerus          = 0
-    @name             = nil
-    @happiness        = species_data.happiness
-    @poke_ball        = :POKEBALL
-    @markings         = []
-    @iv               = {}
-    @ivMaxed          = {}
-    @ev               = {}
-    GameData::Stat.each_main do |s|
-      @iv[s.id]       = 0#rand(IV_STAT_LIMIT + 1) #by low
-      @ev[s.id]       = 0
-    end
-    case owner
-    when Owner
-      @owner = owner
-    when Player, NPCTrainer
-      @owner = Owner.new_from_trainer(owner)
-    else
-      @owner = Owner.new(0, "", 2, 2)
-    end
-    @obtain_method    = 0   # Met
-    @obtain_method    = 4 if $game_switches && $game_switches[Settings::FATEFUL_ENCOUNTER_SWITCH]
-    @obtain_map       = ($game_map) ? $game_map.map_id : 0
-    @obtain_text      = nil
-    @obtain_level     = level
-    @hatched_map      = 0
-    @timeReceived     = pbGetTimeNow.to_i
-    @timeEggHatched   = nil
-    @fused            = nil
-    @personalID       = rand(2**16) | (rand(2**16) << 16)
-    @hp               = 1
-    @totalhp          = 1
-    #by low
-    @evolution_steps  = 0
-    @remaningHPBars   = [0, 0] # current, max hp bar
-    @hpbarsstorage    = [0, 0] # break, restore hp bar
-    @willmega         = false
-    @sketchMove       = nil
-    calc_stats
-    if @form == 0 && recheck_form
-      f = MultipleForms.call("getFormOnCreation", self)
-      if f
-        self.form = f
-        reset_moves if withMoves
-      end
-    end
   end
 end
         

--- a/Plugins/Full Odds Tracker/Script.rb
+++ b/Plugins/Full Odds Tracker/Script.rb
@@ -1,5 +1,6 @@
 class Pokemon
   # Number of times this pokemon has rolled for shininess
+  # Can be set to 2 to manually mark as not-full-odds
   attr_accessor   :shiny_roll_count
 
   # Indicates full odds, not shininess - a non-shiny pokemon can still return true
@@ -12,16 +13,34 @@ class Pokemon
   # Shiny calculation - added code to keep track of shiny rolls
   def shiny?
     if @shiny.nil?
-      @shiny_roll_count += 1
+      @shiny_roll_count = 0 if @shiny_roll_count.nil?
+      @shiny_roll_count = @shiny_roll_count + 1
+      echoln "Rolling for shininess..."
     end
     return fo_shiny?
   end
 
-  alias fo_initialize initialize
-  # Creates a new Pokémon object - added code to initialise counter for shiny rolls
-  def initialize(*args)
-    fo_initialize(*args)
-    @shiny_roll_count = 0
+  # Also overriding shiny setting code, so that if shiny is set to true this is
+  # manually marked as not-full-odds
+  def shiny=(value)
+    @shiny_roll_count = 2 if value == true
+    if value == true
+        echoln "Invalidated due to set shiny"
+    end
+    @shiny = value
   end
 end
+
+EventHandlers.add(:on_wild_pokemon_created, :full_odds_switch,
+  proc { |pkmn|
+    if $bag.has?(:SHINYCHARM)
+        pkmn.shiny_roll_count = 2
+        echoln "Invalidated due to shiny charm"
+    end
+    if $player.pokedex.battled_count(pkmn.species) > 51 && Settings::HIGHER_SHINY_CHANCES_WITH_NUMBER_BATTLED
+        pkmn.shiny_roll_count = 2
+        echoln "Invalidated due to higher shiny chance from number fought"
+    end
+  }
+)
         

--- a/Plugins/Full Odds Tracker/meta.txt
+++ b/Plugins/Full Odds Tracker/meta.txt
@@ -1,0 +1,4 @@
+Name       = Full Odds Tracker
+Version    = 0.1
+Essentials = 20.1
+Credits    = Delphilly


### PR DESCRIPTION
Adjusts icon alignment for shiny + mega ( Resolves #1366 ) and adds a plugin to keep track of whether a shiny was caught at full odds. Need to add icon to resolve 1382 - could use hue shifted shiny icon, but 1366 implies we might want to change the shiny icon entirely anyway?